### PR TITLE
fix: amélioration du parsing markdown pour les balises suivies de \n

### DIFF
--- a/ai_middleware/services/markdown_service.py
+++ b/ai_middleware/services/markdown_service.py
@@ -115,20 +115,22 @@ def from_markdown(markdown_text):
 
         # Première passe : Créer ou mettre à jour les objets
         for line in lines:
-            header_match = re.match(r'^#+\s+\[@(\w+)::(\S+?)\]\s*(.+)?$', line)
+            # Modifié pour gérer les balises suivies de \n en rendant la partie champs optionnelle
+            header_match = re.match(r'^#+\s+\[@(\w+)::(\S+?)\](?:\s*(.+)?)?$', line)
             if not header_match:
                 continue
 
             model_name, obj_uuid, fields_text = header_match.groups()
             model_class = globals().get(model_name)
-            if not model_class or not fields_text:
+            if not model_class:
                 continue
 
-            # Extraire les champs
+            # Extraire les champs si présents
             fields = {}
-            for match in re.finditer(r'\*\*(\w+)\*\*:\s*([^*]+?)(?=\s+\*\*|$)', fields_text):
-                field_name, value = match.groups()
-                fields[field_name] = value.strip()
+            if fields_text:
+                for match in re.finditer(r'\*\*(\w+)\*\*:\s*([^*]+?)(?=\s+\*\*|$)', fields_text):
+                    field_name, value = match.groups()
+                    fields[field_name] = value.strip()
 
             # Créer ou mettre à jour l'objet
             try:
@@ -156,12 +158,12 @@ def from_markdown(markdown_text):
 
         # Deuxième passe : Établir les relations
         for line in lines:
-            header_match = re.match(r'^#+\s+\[@(\w+)::(\S+?)\]\s*(.+)?$', line)
+            header_match = re.match(r'^#+\s+\[@(\w+)::(\S+?)\](?:\s*(.+)?)?$', line)
             if not header_match:
                 continue
 
             model_name, obj_uuid, fields_text = header_match.groups()
-            if obj_uuid in model_objects:
+            if obj_uuid in model_objects and fields_text:
                 obj = model_objects[obj_uuid]
                 relationships = {}
                 for match in re.finditer(r'\*\*(\w+)\*\*:\s*([^*]+?)(?=\s+\*\*|$)', fields_text):


### PR DESCRIPTION
Cette PR corrige un problème de parsing dans le service markdown où les balises immédiatement suivies par \n n'étaient pas reconnues correctement.

Changements :
- Modification de la regex de parsing pour rendre la partie des champs optionnelle
- Ajout de la vérification de la présence des champs avant de les traiter
- Mise à jour des deux passes de parsing pour utiliser la même regex modifiée

Exemple avant :
```markdown
# [@Client::774a0fcd-08b9-48a9-8624-b0d66e55a765]\n
```
Ne fonctionnait pas car la regex attendait des champs après la balise.

Exemple après :
```markdown
# [@Client::774a0fcd-08b9-48a9-8624-b0d66e55a765]\n
```
Fonctionne maintenant car la regex a été modifiée pour rendre les champs optionnels.